### PR TITLE
Cache remapping weights

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -23,6 +23,8 @@ Released on 2021, ???.
   (`#31 <https://github.com/hydro-jules/cm4twc/issues/31>`_)
 * add time slice for I/O operations (user customisable)
   (`#42 <https://github.com/hydro-jules/cm4twc/pull/42>`_)
+* cache remapping weights at initialisation
+  (`#44 <https://github.com/cm4twc-org/cm4twc/pull/44>`_)
 
 .. rubric:: Documentation
 

--- a/cm4twc/_utils/exchanger.py
+++ b/cm4twc/_utils/exchanger.py
@@ -303,7 +303,7 @@ class Exchanger(object):
         if self.transfers[name][component]['remap'] is not None:
             src, remap = self.transfers[name][component]['remap']
             src[:] = value
-            value = src.regrids(remap, 'conservative').array
+            value = src.regrids(remap).array
 
         # record that another value was retrieved by incrementing count
         self.transfers[name][component]['iter'] += 1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 numpy>=1.16
 netCDF4>=1.5
 esmpy
-cftime>=1.3.0,<1.4.0
+cftime
 cfunits
-cf-python>=3.7
+cf-python>=3.10.0
 pyyaml>=5.3
 pyproj>=3.0


### PR DESCRIPTION
resolve #43 

Following a PR in `cf-python` https://github.com/NCAS-CMS/cf-python/pull/223, the `regrids`/`regridc` methods of a `cf.Field` can now return a `RegridOperator` so that the remapping weights are calculated then, and stored in the RegridOperator which can be re-used on demand later on.

This PR makes use of this new feature is the `set_up` of the `Exchanger`, where the `RegridOperator` is computed once if remapping is required, and then used in `get_transfer`.

This PR requires `cf-python>=3.10.0` to work, so I expect our tests to fail because this version has not been released on PyPI yet. While their PR is merged in their master branch already, I would rather not modify our GitHub Actions workflow to install from their repo rather than from PyPI.